### PR TITLE
Fix include Shape.h

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -16,7 +16,7 @@
 #include <ctime>
 #include "screen.h"
 #include "camera.h"
-#include "shape.h"
+#include "Shape.h"
 
 const float PI = 3.141592f;
 

--- a/mainOptimised.cpp
+++ b/mainOptimised.cpp
@@ -20,7 +20,7 @@
 #include <omp.h>
 #include "screen.h"
 #include "camera.h"
-#include "shape.h"
+#include "Shape.h"
 
 const float PI = 3.141592f;
 


### PR DESCRIPTION
## What?
Fixed the inclution of Shape.h

## How?
Changed include statement from `shape.h` to `Shape.h` in `main.cpp` and `mainOptimised.cpp`.

## Anything Else?
Based on the naming of `Ray.h`, I assumed that the filename was intended to start with a capital letter, so I changed the include statement instead of the filename.

Thanks for such an awesome creation! :tada: 